### PR TITLE
Fix interview stats: Use final_decision for accepted/rejected counts

### DIFF
--- a/api_server.py
+++ b/api_server.py
@@ -741,6 +741,7 @@ def get_applicant_status():
         decision_made_at = None
         appointment_date = None
         appointment_time = None
+        appointment_status = None
         
         for apt in appointments:
             # Infer final_decision from status if not explicitly set
@@ -758,7 +759,13 @@ def get_applicant_status():
                 decision_made_at = apt.get('decision_made_at') or apt.get('updated_at')
                 appointment_date = apt.get('scheduled_date')
                 appointment_time = apt.get('scheduled_time')
+                appointment_status = status
                 break  # Get the most recent one with a decision
+            elif status and not appointment_status:
+                # Store the most recent appointment status even if no decision yet
+                appointment_status = status
+                appointment_date = apt.get('scheduled_date')
+                appointment_time = apt.get('scheduled_time')
         
         loop.close()
         

--- a/database_optimized.py
+++ b/database_optimized.py
@@ -650,14 +650,23 @@ class DatabaseOptimized:
         with self.get_connection() as conn:
             cursor = conn.cursor()
             
-            # Get appointment counts by status
+            # Get appointment counts by status and final_decision
+            # For accepted/rejected, use final_decision if available, otherwise infer from status
             cursor.execute('''
                 SELECT 
                     COUNT(*) as total_appointments,
                     SUM(CASE WHEN status = 'scheduled' THEN 1 ELSE 0 END) as scheduled,
-                    SUM(CASE WHEN status = 'completed' THEN 1 ELSE 0 END) as completed,
                     SUM(CASE WHEN status = 'cancelled' THEN 1 ELSE 0 END) as cancelled,
-                    SUM(CASE WHEN status = 'no_show' THEN 1 ELSE 0 END) as no_show
+                    SUM(CASE 
+                        WHEN final_decision = 'accepted' THEN 1 
+                        WHEN final_decision IS NULL AND status = 'completed' THEN 1 
+                        ELSE 0 
+                    END) as accepted,
+                    SUM(CASE 
+                        WHEN final_decision = 'rejected' THEN 1 
+                        WHEN final_decision IS NULL AND status = 'no_show' THEN 1 
+                        ELSE 0 
+                    END) as rejected
                 FROM appointments
             ''')
             
@@ -665,9 +674,9 @@ class DatabaseOptimized:
             return {
                 'total_appointments': result[0] or 0,
                 'scheduled': result[1] or 0,
-                'accepted': result[2] or 0,  # completed = accepted
-                'rejected': result[4] or 0,  # no_show = rejected
-                'cancelled': result[3] or 0
+                'accepted': result[3] or 0,  # Based on final_decision or status
+                'rejected': result[4] or 0,  # Based on final_decision or status
+                'cancelled': result[2] or 0
             }
     
     async def get_appointments(self, search_query: str = None) -> List[Dict[str, Any]]:


### PR DESCRIPTION
- Updated get_schedule_stats() to count accepted/rejected based on final_decision field
- Falls back to status (completed/no_show) for backward compatibility
- Fixes display issue on interview management page cards